### PR TITLE
Fix/concat document definitions

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -41,10 +41,23 @@ function expandImports(source, doc) {
 
 module.exports = function(source) {
   this.cacheable();
-  const doc = gql`${source}`;
+  const doc = gql(source, true);
+  
+  if (doc.definitions) {
+    for (var i = 0; i < doc.definitions.length; i++) {
+      if (doc.definitions[i].loc) {
+        doc.definitions[i].loc = {
+          start: doc.definitions[i].loc.start,
+          end: doc.definitions[i].loc.end,
+          source: doc.definitions[i].loc.source
+        }
+      }
+    }
+  }
+  
   let headerCode = `
-    var doc = ${JSON.stringify(doc)};
-    doc.loc.source = ${JSON.stringify(doc.loc.source)};
+    var doc = ${JSON.stringify(doc, null, 4)};
+    doc.loc.source = ${JSON.stringify(doc.loc.source, null, 4)};
   `;
 
   let outputCode = "";


### PR DESCRIPTION
Issue Fixed #159

## Proposed Changes
  - Concatenate document definitions while filtering for duplicates

@daniellmb

Based on PR #105 by @evanrs, updated for current version of graphql-tag

> Document fragments parsed by `graphql-tag/loader` lose their definitions when used with a `gql` tagged template literal. This is fixed by concatenating the document definitions—filtering for duplicates.
> 
> Without this, the following would fail:
> 
> ```js
> import catFaceFragment from './catFaceFragment.gql';
> 
> const query = gql`
>   query Kitten($name: String) {
>     kitten(name: $name) {
>       ... CatFace
>     }
>   }
>   ${catFaceFragment}
> `
> ```
> 
> ```graphql
> #import "./whiskers.gql"
> 
> fragment CatFace on Cat {
>   ... Whiskers
> }
> ```
> 
> ```graphql
> fragment Whiskers on Cat {
>   whiskers {
>     quantity
>     length
>     areWiderThanBody
>   }  
> }
> ```
> 
> ```
> Unknown fragment "Whiskers".
> ```


